### PR TITLE
Exclude people from scoreboard with less than 3 games played

### DIFF
--- a/src/server/router/user.ts
+++ b/src/server/router/user.ts
@@ -78,6 +78,11 @@ export const userRouter = createRouter()
           matchesWon: true,
           elo: true
         },
+         where: {
+          matchesPlayed: {
+            gte: 3
+          }
+        },
         orderBy: {
           elo: 'desc'
         }


### PR DESCRIPTION
This pull request updates the `userRouter` in `src/server/router/user.ts` to filter users based on the number of matches played. The change ensures that only users who have played at least three matches are included in the results.

* [`src/server/router/user.ts`](diffhunk://#diff-1dab91318f23a19a2156cd3674ef001336868133de1f1aa96af1ab6ece7cbb74R80-R84): Added a `where` clause to filter users with `matchesPlayed` greater than or equal to 3 in the query.