### PR TITLE
Match form submission updates

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,5 +14,8 @@ function defineNextConfig(config) {
 
 export default defineNextConfig({
   reactStrictMode: true,
-  swcMinify: true
+  swcMinify: true,
+  images: {
+    domains: ['lh3.googleusercontent.com']
+  }
 });

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "postinstall": "prisma generate"
+    "postinstall": "prisma generate",
+    "seed": "node prisma/seeder.js"
   },
   "dependencies": {
     "@next-auth/prisma-adapter": "^1.0.4",

--- a/src/components/dashboard/NewGameForm.tsx
+++ b/src/components/dashboard/NewGameForm.tsx
@@ -7,6 +7,12 @@ import SectionTitle from '../shared/SectionTitle';
 import { ArrowRightCircle, ChevronDown, RotateCw } from 'lucide-react';
 import SectionCard from '../shared/SectionCard';
 
+interface ScoreButtonGroupProps {
+  score: number;
+  setScore: (score: number) => void;
+  disabled?: boolean;
+}
+
 interface PlayerSelectProps {
   label: 'One' | 'Two';
   name: string;
@@ -81,6 +87,31 @@ const NewGameForm: FC = () => {
     setPlayerTwoScore(0);
   };
 
+  const ScoreButtonGroup: FC<ScoreButtonGroupProps> = ({ score, setScore, disabled}) => {
+    const increments = [1, 5, 11];
+
+    return (
+        <div className="inline-flex w-full mt-2">
+          {increments.map((inc, idx) => (
+            <button
+              key={inc}
+              type="button"
+              disabled={disabled}
+              onClick={() => setScore(score + inc)}
+              className={clsx(
+                'w-full px-2 py-1 text-xs border border-slate-300 bg-slate-50 hover:bg-slate-100',
+                idx === 0 && 'rounded-l-lg',
+                idx === increments.length - 1 && 'rounded-r-lg',
+                idx > 0 && '-ml-px'
+              )}
+            >
+              +{inc}
+            </button>
+          ))}
+        </div>
+    );
+  }
+
   const PlayerSelect: FC<PlayerSelectProps> = ({ label, name, setName }) => (
     <div className="flex flex-col w-full">
       <label htmlFor={name} className="mb-1 text-xs text-slate-400">
@@ -139,34 +170,48 @@ const NewGameForm: FC = () => {
     <SectionCard>
       <SectionTitle title="📝 &nbsp;New Game" />
       <div className="flex flex-row w-full gap-4">
-        <div className="flex flex-row w-full">
-          <PlayerSelect label="One" name={playerOneId} setName={setPlayerOneId} />
-          <input
-            className={clsx(
-              'border text-gray-900 text-sm rounded-sm block w-12 py-1 px-2 ml-1 cursor-default self-end h-8',
-              errors.playerOneScore ? 'border-red-500' : 'border-slate-300'
-            )}
-            type={'number'}
-            min={0}
-            ref={playerOneInputRef}
-            value={playerOneScore}
+        <div className="w-full">
+          <div className='flex flex-row w-full'>
+            <PlayerSelect label="One" name={playerOneId} setName={setPlayerOneId} />
+            <input
+              className={clsx(
+                'border text-gray-900 text-sm rounded-sm block w-12 py-1 px-2 ml-1 cursor-default self-end h-8',
+                errors.playerOneScore ? 'border-red-500' : 'border-slate-300'
+              )}
+              type={'number'}
+              min={0}
+              ref={playerOneInputRef}
+              value={playerOneScore}
+              disabled={match.isLoading}
+              onChange={(e) => setPlayerOneScore(parseInt(e.target.value))}
+            />
+          </div>
+          <ScoreButtonGroup
+            score={playerOneScore}
+            setScore={setPlayerOneScore}
             disabled={match.isLoading}
-            onChange={(e) => setPlayerOneScore(parseInt(e.target.value))}
           />
         </div>
-        <div className="flex flex-row w-full">
-          <PlayerSelect label="Two" name={playerTwoId} setName={setPlayerTwoId} />
-          <input
-            className={clsx(
-              'border text-gray-900 text-sm rounded-sm block w-12 py-1 px-2 ml-1 cursor-default self-end h-8',
-              errors.playerTwoScore ? 'border-red-500' : 'border-slate-300'
-            )}
-            type={'number'}
-            min={0}
-            ref={playerTwoInputRef}
-            value={playerTwoScore}
+        <div className='w-full'>
+          <div className='flex flex-row w-full'>
+            <PlayerSelect label="Two" name={playerTwoId} setName={setPlayerTwoId} />
+            <input
+              className={clsx(
+                'border text-gray-900 text-sm rounded-sm block w-12 py-1 px-2 ml-1 cursor-default self-end h-8',
+                errors.playerTwoScore ? 'border-red-500' : 'border-slate-300'
+              )}
+              type={'number'}
+              min={0}
+              ref={playerTwoInputRef}
+              value={playerTwoScore}
+              disabled={match.isLoading}
+              onChange={(e) => setPlayerTwoScore(parseInt(e.target.value))}
+            />
+          </div>
+          <ScoreButtonGroup
+            score={playerTwoScore}
+            setScore={setPlayerTwoScore}
             disabled={match.isLoading}
-            onChange={(e) => setPlayerTwoScore(parseInt(e.target.value))}
           />
         </div>
       </div>

--- a/src/components/dashboard/NewGameForm.tsx
+++ b/src/components/dashboard/NewGameForm.tsx
@@ -6,6 +6,7 @@ import { useQueryClient } from 'react-query';
 import SectionTitle from '../shared/SectionTitle';
 import { ArrowRightCircle, ChevronDown, RotateCw } from 'lucide-react';
 import SectionCard from '../shared/SectionCard';
+import Avatar from '../shared/Avatar';
 
 interface ScoreButtonGroupProps {
   score: number;
@@ -29,6 +30,9 @@ const NewGameForm: FC = () => {
   const users = trpc.useQuery(['user.getAll']);
   const match = trpc.useMutation(['match.create']);
   const { data: session } = useSession();
+  const frequentlyPlayed = trpc.useQuery(['user.frequentlyPlayed', { id: session?.user?.id ?? '' }], {
+    enabled: !!session?.user?.id
+  });
 
   const [playerOneId, setPlayerOneId] = useState(session?.user?.id ?? '');
   const [playerTwoId, setPlayerTwoId] = useState('');
@@ -80,6 +84,7 @@ const NewGameForm: FC = () => {
           queryClient.invalidateQueries(['user.scoreboard']);
           queryClient.invalidateQueries(['user.stats']);
           queryClient.invalidateQueries(['user.insights']);
+          queryClient.invalidateQueries(['user.frequentlyPlayed']);
         }
       }
     );
@@ -87,30 +92,30 @@ const NewGameForm: FC = () => {
     setPlayerTwoScore(0);
   };
 
-  const ScoreButtonGroup: FC<ScoreButtonGroupProps> = ({ score, setScore, disabled}) => {
+  const ScoreButtonGroup: FC<ScoreButtonGroupProps> = ({ score, setScore, disabled }) => {
     const increments = [1, 5, 11];
 
     return (
-        <div className="inline-flex w-full mt-2">
-          {increments.map((inc, idx) => (
-            <button
-              key={inc}
-              type="button"
-              disabled={disabled}
-              onClick={() => setScore(score + inc)}
-              className={clsx(
-                'w-full px-2 py-1 text-xs border border-slate-300 bg-slate-50 hover:bg-slate-100',
-                idx === 0 && 'rounded-l-lg',
-                idx === increments.length - 1 && 'rounded-r-lg',
-                idx > 0 && '-ml-px'
-              )}
-            >
-              +{inc}
-            </button>
-          ))}
-        </div>
+      <div className="inline-flex w-full mt-2">
+        {increments.map((inc, idx) => (
+          <button
+            key={inc}
+            type="button"
+            disabled={disabled}
+            onClick={() => setScore(score + inc)}
+            className={clsx(
+              'w-full px-2 py-1 text-xs border border-slate-300 bg-slate-50 hover:bg-slate-100',
+              idx === 0 && 'rounded-l-lg',
+              idx === increments.length - 1 && 'rounded-r-lg',
+              idx > 0 && '-ml-px'
+            )}
+          >
+            +{inc}
+          </button>
+        ))}
+      </div>
     );
-  }
+  };
 
   const PlayerSelect: FC<PlayerSelectProps> = ({ label, name, setName }) => (
     <div className="flex flex-col w-full">
@@ -171,7 +176,7 @@ const NewGameForm: FC = () => {
       <SectionTitle title="📝 &nbsp;New Game" />
       <div className="flex flex-row w-full gap-4">
         <div className="w-full">
-          <div className='flex flex-row w-full'>
+          <div className="flex flex-row w-full">
             <PlayerSelect label="One" name={playerOneId} setName={setPlayerOneId} />
             <input
               className={clsx(
@@ -186,14 +191,10 @@ const NewGameForm: FC = () => {
               onChange={(e) => setPlayerOneScore(parseInt(e.target.value))}
             />
           </div>
-          <ScoreButtonGroup
-            score={playerOneScore}
-            setScore={setPlayerOneScore}
-            disabled={match.isLoading}
-          />
+          <ScoreButtonGroup score={playerOneScore} setScore={setPlayerOneScore} disabled={match.isLoading} />
         </div>
-        <div className='w-full'>
-          <div className='flex flex-row w-full'>
+        <div className="w-full">
+          <div className="flex flex-row w-full">
             <PlayerSelect label="Two" name={playerTwoId} setName={setPlayerTwoId} />
             <input
               className={clsx(
@@ -208,11 +209,34 @@ const NewGameForm: FC = () => {
               onChange={(e) => setPlayerTwoScore(parseInt(e.target.value))}
             />
           </div>
-          <ScoreButtonGroup
-            score={playerTwoScore}
-            setScore={setPlayerTwoScore}
-            disabled={match.isLoading}
-          />
+          <ScoreButtonGroup score={playerTwoScore} setScore={setPlayerTwoScore} disabled={match.isLoading} />
+        </div>
+      </div>
+
+      <div className="mt-6">
+        <p className="mb-1 text-xs text-slate-400">Frequently Played Against</p>
+        <div className="flex flex-row flex-wrap gap-2">
+          {frequentlyPlayed.isLoading &&
+            Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="flex flex-col items-center w-20 animate-pulse">
+                <div className="w-12 h-12 bg-slate-200 rounded-full" />
+                <div className="h-2 w-10 mt-2 bg-slate-200 rounded" />
+              </div>
+            ))}
+
+          {frequentlyPlayed.data && frequentlyPlayed.data.length > 0
+            ? frequentlyPlayed.data.map((player) => (
+                <button
+                  key={player.id}
+                  type="button"
+                  onClick={() => setPlayerTwoId(player.id)}
+                  disabled={match.isLoading || player.id === playerOneId}
+                  className="flex flex-col items-center w-20 p-2 rounded-lg hover:bg-slate-100 disabled:hover:bg-transparent disabled:opacity-40"
+                >
+                  <Avatar image={player.image} name={player.name ?? 'Player'} />
+                </button>
+              ))
+            : !frequentlyPlayed.isLoading && <p className="text-sm">No game history yet.</p>}
         </div>
       </div>
 

--- a/src/components/dashboard/NewGameForm.tsx
+++ b/src/components/dashboard/NewGameForm.tsx
@@ -79,7 +79,6 @@ const NewGameForm: FC = () => {
     );
     setPlayerOneScore(0);
     setPlayerTwoScore(0);
-    setPlayerTwoId('');
   };
 
   const PlayerSelect: FC<PlayerSelectProps> = ({ label, name, setName }) => (

--- a/src/components/shared/Avatar.tsx
+++ b/src/components/shared/Avatar.tsx
@@ -1,0 +1,60 @@
+import Image from 'next/image';
+import { FC } from 'react';
+
+interface Props {
+  image: string | null | undefined;
+  name: string;
+  size?: number;
+  bgColor?: string;
+  fgColor?: string;
+}
+
+const Avatar: FC<Props> = ({ image, name, size = 48, bgColor = '#f0f0f0', fgColor = '#555555' }) => {
+  const firstName = name.split(' ')[0];
+  console.log(firstName);
+  const displayName = firstName || name;
+
+  if (!image) {
+    const initials = name!
+      .split(' ')
+      .map((word) => word[0])
+      .slice(0, 2)
+      .join('')
+      .toUpperCase();
+
+    return (
+      <>
+        <svg width={size} height={size} viewBox="0 0 100 100" className="rounded-full">
+          <rect width="100" height="100" fill={bgColor} />
+          <text
+            x="50"
+            y="50"
+            textAnchor="middle"
+            dominantBaseline="central"
+            fontSize="50"
+            fill={fgColor}
+            style={{ fontFamily: 'Arial, sans-serif' }}
+          >
+            {initials}
+          </text>
+        </svg>
+        <span className="text-xs mt-1.5 text-slate-600 truncate w-full text-center">{displayName}</span>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Image
+        src={image}
+        alt={displayName}
+        width={size}
+        height={size}
+        className="w-12 h-12 rounded-full object-cover border-2 border-slate-200"
+      />
+      <span className="text-xs mt-1.5 text-slate-600 truncate w-full text-center">{displayName}</span>
+    </>
+  );
+};
+
+export default Avatar;

--- a/src/components/shared/Avatar.tsx
+++ b/src/components/shared/Avatar.tsx
@@ -11,7 +11,6 @@ interface Props {
 
 const Avatar: FC<Props> = ({ image, name, size = 48, bgColor = '#f0f0f0', fgColor = '#555555' }) => {
   const firstName = name.split(' ')[0];
-  console.log(firstName);
   const displayName = firstName || name;
 
   if (!image) {


### PR DESCRIPTION
### Summary
This PR enhances the match submissions flow by introducing a "Frequently Played Against" section, improving player selection, and adding reusable UI components.

### Changes
* **Next.js config**
  * Added `images.domains` to allow serving Google profile avatars.

* **Package.json**
  * Run the seed script (`node prisma/seeder.js`) using `npm run seed`.

* **NewGameForm component**
  * Added a new tRPC query `user.frequentlyPlayed` to suggest opponents based on past matches.
  * Added `ScoreButtonGroup` component for quick score increments (+1, +5, +11).
  * Added `Avatar` component to show opponent profile images or initials in the form.
  * Removed "Player Two" resetting after form submission for cases where there are multi-round matches.

### Screenshots
<img width="526" height="385" alt="image" src="https://github.com/user-attachments/assets/dc38ffce-0748-4072-acef-919394ec879b" />